### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/make_eml_with_r/make_eml_with_r_and_share_with_github.Rmd
+++ b/make_eml_with_r/make_eml_with_r_and_share_with_github.Rmd
@@ -92,7 +92,7 @@ install.packages("EML", repos = c("http://packages.ropensci.org", "https://cran.
 library(EML)
 ```    
 
-Carl Boettiger, Maëlle Salmon, Claas-Thido Pfaff, Matt Jones, Anna Liu, Karthik Ram, Bryce Mecum, Duncan Temple Lang, Edmund Hart, Matthias Grenié, Ivan Hanigan. (2017, May 11). ropensci/EML:v1.0.3. Zenodo. http://doi.org/10.5281/zenodo.574208
+Carl Boettiger, Maëlle Salmon, Claas-Thido Pfaff, Matt Jones, Anna Liu, Karthik Ram, Bryce Mecum, Duncan Temple Lang, Edmund Hart, Matthias Grenié, Ivan Hanigan. (2017, May 11). ropensci/EML:v1.0.3. Zenodo. https://doi.org/10.5281/zenodo.574208
 
 
 ##Exercise (create the \<attributeList> element)

--- a/make_eml_with_r/make_eml_with_r_and_share_with_github.html
+++ b/make_eml_with_r/make_eml_with_r_and_share_with_github.html
@@ -190,7 +190,7 @@ $(document).ready(function () {
 
 library(EML)</code></pre></li>
 </ul>
-<p>Carl Boettiger, MaÃ«lle Salmon, Claas-Thido Pfaff, Matt Jones, Anna Liu, Karthik Ram, Bryce Mecum, Duncan Temple Lang, Edmund Hart, Matthias GreniÃ©, Ivan Hanigan. (2017, May 11). ropensci/EML:v1.0.3. Zenodo. <a href="http://doi.org/10.5281/zenodo.574208" class="uri">http://doi.org/10.5281/zenodo.574208</a></p>
+<p>Carl Boettiger, MaÃ«lle Salmon, Claas-Thido Pfaff, Matt Jones, Anna Liu, Karthik Ram, Bryce Mecum, Duncan Temple Lang, Edmund Hart, Matthias GreniÃ©, Ivan Hanigan. (2017, May 11). ropensci/EML:v1.0.3. Zenodo. <a href="https://doi.org/10.5281/zenodo.574208" class="uri">https://doi.org/10.5281/zenodo.574208</a></p>
 </div>
 <div id="exercise-create-the-attributelist-element" class="section level2">
 <h2>Exercise (create the &lt;attributeList&gt; element)</h2>

--- a/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.Rpres
+++ b/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.Rpres
@@ -77,9 +77,9 @@ Main resources for this tutorial (continued):
 Two example data sets from the EDI repository:
 
 
-- "Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)": http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
+- "Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)": https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
 
--  "Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31": http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
+-  "Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31": https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
 
 <br />
 <br />
@@ -106,7 +106,7 @@ Important dplyr functions for data manipulation
 class: small-code
 IMPORT DATA:"Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)"
 <br />
-http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
+https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
 <br />
 <br />
 
@@ -318,7 +318,7 @@ ggplot(t5) + geom_col(mapping = aes(x=Species,y=count_mean,fill=Species)) +
 class: small-code
 IMPORT DATA:"Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31"
 <br />
-http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
+https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
 <br />
 <br />
 

--- a/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.html
+++ b/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.html
@@ -872,8 +872,8 @@ by Hadley Wickham and Garrett Grolemund (O&#39;Reilly). Copyright 2017 Garrett G
 Two example data sets from the EDI repository:</p>
 
 <ul>
-<li><p>&ldquo;Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)&rdquo;: <a href="http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e">http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e</a></p></li>
-<li><p>&ldquo;Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31&rdquo;: <a href="http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669">http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669</a>.</p></li>
+<li><p>&ldquo;Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)&rdquo;: <a href="https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e">https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e</a></p></li>
+<li><p>&ldquo;Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31&rdquo;: <a href="https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669">https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669</a>.</p></li>
 </ul>
 
 <p><br />
@@ -912,7 +912,7 @@ R CHEAT SHEETS: <a href="https://www.rstudio.com/resources/cheatsheets/">https:/
 <div class="slideContent noTitle small-code" >
 <p>IMPORT DATA:&ldquo;Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)&rdquo;
 <br />
-<a href="http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e">http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e</a>
+<a href="https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e">https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e</a>
 <br />
 <br /></p>
 
@@ -1259,7 +1259,7 @@ t5
 <div class="slideContent noTitle small-code" >
 <p>IMPORT DATA:&ldquo;Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31&rdquo;
 <br />
-<a href="http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669">http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669</a>.
+<a href="https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669">https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669</a>.
 <br />
 <br /></p>
 

--- a/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.md
+++ b/r_tutorial_tidyverse/tidyr_1_r_tutorial_edi.md
@@ -77,9 +77,9 @@ Main resources for this tutorial (continued):
 Two example data sets from the EDI repository:
 
 
-- "Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)": http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
+- "Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)": https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
 
--  "Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31": http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
+-  "Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31": https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
 
 <br />
 <br />
@@ -106,7 +106,7 @@ Important dplyr functions for data manipulation
 class: small-code
 IMPORT DATA:"Rainfall manipulation study vegetation data from the Chihuahuan Desert Grassland and Creosote Shrubland at the Sevilleta National Wildlife Refuge, New Mexico (2003-2011)"
 <br />
-http://dx.doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
+https://doi.org/10.6073/pasta/361fbce9ce7d4d9530e34b4a8ee3c02e
 <br />
 <br />
 
@@ -447,7 +447,7 @@ ggplot(t5) + geom_col(mapping = aes(x=Species,y=count_mean,fill=Species)) +
 class: small-code
 IMPORT DATA:"Eddy covariance data measured at the CAP LTER flux tower located in the west Phoenix, AZ neighborhood of Maryvale from 2011-12-16 through 2012-12-31"
 <br />
-http://dx.doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
+https://doi.org/10.6073/pasta/fed17d67583eda16c439216ca40b0669.
 <br />
 <br />
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update of all static DOI links.

Cheers!